### PR TITLE
update: remove unwanted character | Fixes #1937

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -679,7 +679,7 @@ class StreamingClient(BaseClient, BaseStream):
             Array of rule IDs, each one representing a rule already active in
             your stream. IDs must be submitted as strings.
         dry_run : bool
-            Set to true to test a the syntax of your rule without submitting
+            Set to true to test the syntax of your rule without submitting
             it. This is useful if you want to check the syntax of a rule before
             removing one or more of your existing rules.
 


### PR DESCRIPTION
Remove unwanted characters from the documentation under StreamingClient.delete_rule.